### PR TITLE
Mate port and thumbnail generation customization

### DIFF
--- a/cover-thumbnailer-gui.py
+++ b/cover-thumbnailer-gui.py
@@ -122,6 +122,7 @@ class Conf(common.Conf):
             #Other
             user_conf_file.write("\n[OTHER]\n")
             user_conf_file.write(self._write_bool("other_enabled"))
+            user_conf_file.write(self._write_str("other_fg"))
             #Ignored
             user_conf_file.write("\n[IGNORED]\n")
             user_conf_file.write(self._write_bool("ignored_dotted"))
@@ -258,6 +259,10 @@ class MainWin(object):
         ### OTHER ###
         #Enable checkBox
         self.cbOtherEnable = win.get_object("cbOtherEnable")
+        #thumbnail decorations configuration
+        self.imgOthersThPreview = win.get_object("imgOthersThPreview")
+        self.btnPickOthersFg = win.get_object("btnPickOthersFg")
+        self.updateOthersThPreview()
 
         ### IGNORED ###
         #Ignored path list
@@ -442,6 +447,15 @@ class MainWin(object):
     def on_cbOtherEnable_toggled(self, widget):
         CONF['other_enabled'] = self.cbOtherEnable.get_active()
 
+    def updateOthersThPreview(self):
+        preview = Thumb([os.path.join(BASE_PATH, "icon.png")])
+        preview.other_thumbnail(CONF['other_fg'])
+        self.imgOthersThPreview.set_from_pixbuf(preview.as_pixbuf())
+        self.updateButtonImage(self.btnPickOthersFg, CONF['other_fg'])
+
+    def on_btnPickOthersFg_clicked(self, widget):
+        self.show_thumbnail_chooser("other_fg")
+
     #~~~ IGNORED ~~~
     def on_btnIgnoredAdd_clicked(self, widget):
         self.fileChooserFor = 'ignored'
@@ -520,6 +534,8 @@ class MainWin(object):
             self.updateMusicThPreview()
         elif self.thumbnailChooserFor.startswith("pictures_"):
             self.updatePicturesThPreview()
+        elif self.thumbnailChooserFor.startswith("other_"):
+            self.updateOthersThPreview()
         self.thumbnailChooserFor = None
 
     def on_thumbnailChooserdialog_delete_event(self, widget, response):

--- a/cover-thumbnailer-gui.py
+++ b/cover-thumbnailer-gui.py
@@ -117,6 +117,8 @@ class Conf(common.Conf):
             user_conf_file.write(self._write_bool("pictures_usegnomefolder"))
             user_conf_file.write(self._write_int("pictures_maxthumbs"))
             user_conf_file.write(self._write_list("pictures_paths"))
+            user_conf_file.write(self._write_str("pictures_bg"))
+            user_conf_file.write(self._write_str("pictures_fg"))
             #Other
             user_conf_file.write("\n[OTHER]\n")
             user_conf_file.write(self._write_bool("other_enabled"))
@@ -247,6 +249,11 @@ class MainWin(object):
         self.cbPicturesKeepFIcon = win.get_object("cbPicturesKeepFIcon")
         #spinbtn_maxThumbs Spin Button
         self.spinbtn_maxThumbs = win.get_object("spinbtn_maxThumbs")
+        #thumbnail decorations configuration
+        self.imgPicturesThPreview = win.get_object("imgPicturesThPreview")
+        self.btnPickPicturesBg = win.get_object("btnPickPicturesBg")
+        self.btnPickPicturesFg = win.get_object("btnPickPicturesFg")
+        self.updatePicturesThPreview()
 
         ### OTHER ###
         #Enable checkBox
@@ -415,6 +422,22 @@ class MainWin(object):
     def on_cb_useGnomePictures_toggled(self, widget):
         CONF['pictures_usegnomefolder'] = self.cb_useGnomePictures.get_active()
 
+    def updatePicturesThPreview(self):
+        preview = Thumb([os.path.join(BASE_PATH, "icon.png")])
+        preview.pictures_thumbnail(
+                CONF['pictures_bg'],
+                CONF['pictures_fg']
+                )
+        self.imgPicturesThPreview.set_from_pixbuf(preview.as_pixbuf())
+        self.updateButtonImage(self.btnPickPicturesBg, CONF['pictures_bg'])
+        self.updateButtonImage(self.btnPickPicturesFg, CONF['pictures_fg'])
+
+    def on_btnPickPicturesBg_clicked(self, widget):
+        self.show_thumbnail_chooser("pictures_bg")
+
+    def on_btnPickPicturesFg_clicked(self, widget):
+        self.show_thumbnail_chooser("pictures_fg")
+
     #~~~ OTHER ~~~
     def on_cbOtherEnable_toggled(self, widget):
         CONF['other_enabled'] = self.cbOtherEnable.get_active()
@@ -495,6 +518,8 @@ class MainWin(object):
         CONF[self.thumbnailChooserFor] = path
         if self.thumbnailChooserFor.startswith("music_"):
             self.updateMusicThPreview()
+        elif self.thumbnailChooserFor.startswith("pictures_"):
+            self.updatePicturesThPreview()
         self.thumbnailChooserFor = None
 
     def on_thumbnailChooserdialog_delete_event(self, widget, response):

--- a/cover-thumbnailer.py
+++ b/cover-thumbnailer.py
@@ -265,6 +265,16 @@ class Thumb(object):
         """
         width = image.size[0]
         height = image.size[1]
+        if width < twidth or height < theight: # scale up if too small
+            if float(width) / twidth < float(height) / theight:
+                new_height = int(round(float(twidth) * height / width))
+                new_width = twidth
+            else:
+                new_width = int(round(float(theight) * width / height))
+                new_height = theight
+            image = image.resize((new_width, new_height))
+            width = image.size[0]
+            height = image.size[1]
         if crop and width >= twidth and height >= theight:
             if width > height:
                 left = int((width - height) / 2)

--- a/cover-thumbnailer.py
+++ b/cover-thumbnailer.py
@@ -207,6 +207,12 @@ class Conf(dict):
                     key = match.group(1)
                     value = match.group(2)
                     self[current_section + "_" + key] = int(value)
+                #Regular string key
+                elif re.match(r"\s*([a-z]+)\s*=\s*\"(.+)\"\s*", line):
+                    match = re.match(r"\s*([a-z]+)\s*=\s*\"(.+)\"\s*", line)
+                    key = match.group(1)
+                    value = match.group(2)
+                    self[current_section + "_" + key] = value
 
             user_conf_file.close()
 
@@ -283,7 +289,7 @@ class Thumb(object):
           * crop -- the resize method (True for having a squared thumbnail)
         """
         #Background picture
-        bg = Image.open(bg_picture).convert("RGB")
+        bg = Image.open(bg_picture).convert("RGBA")
         bg_width = bg.size[0]
         bg_height = bg.size[1]
         #Album cover
@@ -313,7 +319,7 @@ class Thumb(object):
         NOTE: call this function ONLY if self.img has, at least, two pictures.
         """
         #Background picture
-        bg = Image.open(bg_picture).convert("RGB")
+        bg = Image.open(bg_picture).convert("RGBA")
         bg_width = bg.size[0]
         bg_height = bg.size[1]
         #Album covers

--- a/install.sh
+++ b/install.sh
@@ -187,8 +187,8 @@ _check_dep() {
 	#Checks dependencies
 
 	echo "$_BOLD * Checking dependencies...$_NORMAL"
-	echo -n "   * Nautilus ............................ "
-	test -x /usr/bin/nautilus && echo "$_GREEN[OK]$_NORMAL" || { echo "$_RED[Missing]$_NORMAL" ; error=1 ; }
+	#echo -n "   * Nautilus ............................ "
+	#test -x /usr/bin/nautilus && echo "$_GREEN[OK]$_NORMAL" || { echo "$_RED[Missing]$_NORMAL" ; error=1 ; }
 	#echo -n "   * Python .............................. "
 	#test -x /usr/bin/python && echo "$_GREEN[OK]$_NORMAL" || { echo "$_RED[Missing]$_NORMAL" ; error=1 ; }
 	echo -n "   * Python Imaging Library (PIL) ........ "

--- a/share/cover-thumbnailer-gui.glade
+++ b/share/cover-thumbnailer-gui.glade
@@ -1174,6 +1174,108 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                             <property name="position">5</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkAlignment" id="alignment11">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="top_padding">10</property>
+                            <child>
+                              <object class="GtkLabel" id="label23">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
+                                <property name="label" translatable="yes">Thumbnail decorations:</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">6</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkHBox" id="hbox11">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">5</property>
+                            <child>
+                              <object class="GtkViewport" id="viewport9">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="shadow_type">etched-in</property>
+                                <child>
+                                  <object class="GtkImage" id="imgPicturesThPreview">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="stock">gtk-missing-image</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkViewport" id="viewport10">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="shadow_type">etched-in</property>
+                                <child>
+                                  <object class="GtkVBox" id="vbox18">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <child>
+                                      <object class="GtkButton" id="btnPickPicturesBg">
+                                        <property name="label" translatable="yes">Background...</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">True</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <signal name="clicked" handler="on_btnPickPicturesBg_clicked" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="btnPickPicturesFg">
+                                        <property name="label" translatable="yes">Foreground...</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">True</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <signal name="clicked" handler="on_btnPickPicturesFg_clicked" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">7</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/share/cover-thumbnailer-gui.glade
+++ b/share/cover-thumbnailer-gui.glade
@@ -150,6 +150,79 @@
       <action-widget response="0">btnErrorPAILClose</action-widget>
     </action-widgets>
   </object>
+  <object class="GtkFileChooserDialog" id="thumbnailchooserdialog">
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Select a folder - Cover Thumbnailer</property>
+    <property name="role">GtkFileChooserDialog</property>
+    <property name="modal">True</property>
+    <property name="window_position">center-on-parent</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="icon_name">document-open</property>
+    <property name="type_hint">normal</property>
+    <property name="skip_taskbar_hint">True</property>
+    <property name="show_hidden">True</property>
+    <signal name="delete-event" handler="on_thumbnailchooserdialog_delete_event" swapped="no"/>
+    <child internal-child="vbox">
+      <object class="GtkVBox" id="dialog2-vbox7">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkHButtonBox" id="dialog2-action_area7">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="btnThumbnailChooserCancel">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
+                <property name="use_stock">True</property>
+                <signal name="clicked" handler="on_btnThumbnailChooserCancel_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btnThumbnailChooserOpen">
+                <property name="label">gtk-open</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
+                <property name="use_stock">True</property>
+                <signal name="clicked" handler="on_btnThumbnailChooserOpen_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="0">btnThumbnailChooserCancel</action-widget>
+      <action-widget response="0">btnThumbnailChooserOpen</action-widget>
+    </action-widgets>
+  </object>
   <object class="GtkAboutDialog" id="winAbout">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
@@ -721,6 +794,123 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                             <property name="expand">False</property>
                             <property name="fill">True</property>
                             <property name="position">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkAlignment" id="alignment10">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="top_padding">10</property>
+                            <child>
+                              <object class="GtkLabel" id="label22">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
+                                <property name="label" translatable="yes">Thumbnail decorations:</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">6</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkHBox" id="hbox10">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">5</property>
+                            <child>
+                              <object class="GtkViewport" id="viewport7">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="shadow_type">etched-in</property>
+                                <child>
+                                  <object class="GtkImage" id="imgMusicThPreview">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="stock">gtk-missing-image</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkViewport" id="viewport8">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="shadow_type">etched-in</property>
+                                <child>
+                                  <object class="GtkVBox" id="vbox17">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <child>
+                                      <object class="GtkButton" id="btnPickMusicBg">
+                                        <property name="label" translatable="yes">Background...</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">True</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <signal name="clicked" handler="on_btnPickMusicBg_clicked" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="btnPickMusicFg">
+                                        <property name="label" translatable="yes">Foreground...</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">True</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <signal name="clicked" handler="on_btnPickMusicFg_clicked" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="btnPickMusicDf">
+                                        <property name="label" translatable="yes">Default Cover...</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">True</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <signal name="clicked" handler="on_btnPickMusicDf_clicked" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">7</property>
                           </packing>
                         </child>
                       </object>

--- a/share/cover-thumbnailer-gui.glade
+++ b/share/cover-thumbnailer-gui.glade
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk+" version="2.16"/>
+  <!-- interface-naming-policy toplevel-contextual -->
   <object class="GtkAdjustment" id="adjustment1">
     <property name="lower">64</property>
     <property name="upper">128</property>
@@ -29,19 +30,18 @@
     <property name="preview_widget_active">False</property>
     <signal name="delete-event" handler="on_filechooserdialog_delete_event" swapped="no"/>
     <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox3">
+      <object class="GtkVBox" id="dialog-vbox3">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area3">
+          <object class="GtkHButtonBox" id="dialog-action_area3">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="btnFileChooserCancel">
                 <property name="label">gtk-cancel</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -58,7 +58,6 @@
             <child>
               <object class="GtkButton" id="btnFileChooserOpen">
                 <property name="label">gtk-open</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -109,12 +108,12 @@
     <property name="secondary_text" translatable="yes">This path was already in the list!</property>
     <signal name="delete-event" handler="on_msgdlgErrorPAIL_delete_event" swapped="no"/>
     <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox7">
+      <object class="GtkVBox" id="dialog-vbox7">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area7">
+          <object class="GtkHButtonBox" id="dialog-action_area7">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
@@ -124,7 +123,6 @@
             <child>
               <object class="GtkButton" id="btnErrorPAILClose">
                 <property name="label">gtk-close</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -185,12 +183,12 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
     <property name="logo">logo.png</property>
     <signal name="delete-event" handler="on_winAbout_delete_event" swapped="no"/>
     <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox1">
+      <object class="GtkVBox" id="dialog-vbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area1">
+          <object class="GtkHButtonBox" id="dialog-action_area1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
@@ -241,7 +239,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                 <child>
                   <object class="GtkLinkButton" id="linkbuttonTranslate">
                     <property name="label" translatable="yes">Translate Cover Thumbnailer</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
@@ -349,7 +346,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                         <child>
                           <object class="GtkCheckButton" id="cbMusicEnable">
                             <property name="label" translatable="yes">Enable Cover Thumbnailer for music folders</property>
-                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">False</property>
@@ -366,7 +362,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                         <child>
                           <object class="GtkCheckButton" id="cbMusicKeepFIcon">
                             <property name="label" translatable="yes">Keep the default folder icon if no cover was found</property>
-                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">False</property>
@@ -423,7 +418,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                         <child>
                                           <object class="GtkRadioButton" id="rbMusicCrop">
                                             <property name="label" translatable="yes">Crop</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
@@ -441,7 +435,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                         <child>
                                           <object class="GtkRadioButton" id="rbMusicPreserve">
                                             <property name="label" translatable="yes">Preserve</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
@@ -545,7 +538,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                         <child>
                                           <object class="GtkRadioButton" id="rbMusicNoMosaic">
                                             <property name="label" translatable="yes">No</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
@@ -563,7 +555,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                         <child>
                                           <object class="GtkRadioButton" id="rbMusicMosaic">
                                             <property name="label" translatable="yes">Yes</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
@@ -649,9 +640,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                         <property name="can_focus">True</property>
                                         <property name="headers_visible">False</property>
                                         <signal name="cursor-changed" handler="on_trvMusicPathList_cursor_changed" swapped="no"/>
-                                        <child internal-child="selection">
-                                          <object class="GtkTreeSelection" id="treeview-selection1"/>
-                                        </child>
                                       </object>
                                     </child>
                                   </object>
@@ -671,7 +659,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                 <child>
                                   <object class="GtkButton" id="btnMusicAdd">
                                     <property name="label">gtk-add</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
@@ -688,7 +675,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                 <child>
                                   <object class="GtkButton" id="btnMusicRemove">
                                     <property name="label">gtk-remove</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="sensitive">False</property>
                                     <property name="can_focus">True</property>
@@ -723,7 +709,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                         <child>
                           <object class="GtkCheckButton" id="cb_useGnomeMusic">
                             <property name="label" translatable="yes" comments="%s will be replaced by the folder path and must be kept unchanged.">Enable for GNOME's music folder (%s)</property>
-                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">False</property>
@@ -796,7 +781,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                         <child>
                           <object class="GtkCheckButton" id="cbPicturesEnable">
                             <property name="label" translatable="yes">Enable Cover Thumbnailer for picture folders</property>
-                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">False</property>
@@ -813,7 +797,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                         <child>
                           <object class="GtkCheckButton" id="cbPicturesKeepFIcon">
                             <property name="label" translatable="yes">Keep the default folder icon if no pictures were found</property>
-                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">False</property>
@@ -850,6 +833,10 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                 <property name="can_focus">True</property>
                                 <property name="max_length">1</property>
                                 <property name="invisible_char">●</property>
+                                <property name="primary_icon_activatable">False</property>
+                                <property name="secondary_icon_activatable">False</property>
+                                <property name="primary_icon_sensitive">True</property>
+                                <property name="secondary_icon_sensitive">True</property>
                                 <property name="adjustment">adjustment2</property>
                                 <property name="climb_rate">1</property>
                                 <property name="snap_to_ticks">True</property>
@@ -914,9 +901,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                         <property name="can_focus">True</property>
                                         <property name="headers_visible">False</property>
                                         <signal name="cursor-changed" handler="on_trvPicturesPathList_cursor_changed" swapped="no"/>
-                                        <child internal-child="selection">
-                                          <object class="GtkTreeSelection" id="treeview-selection2"/>
-                                        </child>
                                       </object>
                                     </child>
                                   </object>
@@ -936,7 +920,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                 <child>
                                   <object class="GtkButton" id="btnPicturesAdd">
                                     <property name="label">gtk-add</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
@@ -953,7 +936,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                 <child>
                                   <object class="GtkButton" id="btnPicturesRemove">
                                     <property name="label">gtk-remove</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="sensitive">False</property>
                                     <property name="can_focus">True</property>
@@ -988,7 +970,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                         <child>
                           <object class="GtkCheckButton" id="cb_useGnomePictures">
                             <property name="label" translatable="yes" comments="%s will be replaced by the folder path and must be kept unchanged.">Enable for GNOME's picture folder (%s)</property>
-                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">False</property>
@@ -1061,7 +1042,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                     <child>
                       <object class="GtkCheckButton" id="cbOtherEnable">
                         <property name="label" translatable="yes">Enable Cover Thumbnailer for other folders</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -1130,7 +1110,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                         <child>
                           <object class="GtkCheckButton" id="cbIgnoreHidden">
                             <property name="label" translatable="yes">Ignore hidden folders (folders whose name starts with a dot)</property>
-                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">False</property>
@@ -1188,9 +1167,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                         <property name="can_focus">True</property>
                                         <property name="headers_visible">False</property>
                                         <signal name="cursor-changed" handler="on_trvIgnoredPathList_cursor_changed" swapped="no"/>
-                                        <child internal-child="selection">
-                                          <object class="GtkTreeSelection" id="treeview-selection3"/>
-                                        </child>
                                       </object>
                                     </child>
                                   </object>
@@ -1210,7 +1186,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                 <child>
                                   <object class="GtkButton" id="btnIgnoredAdd">
                                     <property name="label">gtk-add</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
@@ -1227,7 +1202,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                 <child>
                                   <object class="GtkButton" id="btnIgnoredRemove">
                                     <property name="label">gtk-remove</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="sensitive">False</property>
                                     <property name="can_focus">True</property>
@@ -1303,9 +1277,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                         <property name="can_focus">True</property>
                                         <property name="headers_visible">False</property>
                                         <signal name="cursor-changed" handler="on_trvNeverIgnoredPathList_cursor_changed" swapped="no"/>
-                                        <child internal-child="selection">
-                                          <object class="GtkTreeSelection" id="treeview-selection4"/>
-                                        </child>
                                       </object>
                                     </child>
                                   </object>
@@ -1325,7 +1296,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                 <child>
                                   <object class="GtkButton" id="btnNeverIgnoredAdd">
                                     <property name="label">gtk-add</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
@@ -1342,7 +1312,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                 <child>
                                   <object class="GtkButton" id="btnNeverIgnoredRemove">
                                     <property name="label">gtk-remove</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="sensitive">False</property>
                                     <property name="can_focus">True</property>
@@ -1436,7 +1405,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                         <child>
                           <object class="GtkCheckButton" id="cbEnableCT">
                             <property name="label" translatable="yes">Enable Cover Thumbnailer</property>
-                            <property name="use_action_appearance">False</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">False</property>
                             <property name="use_action_appearance">False</property>
@@ -1474,6 +1442,10 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                                 <property name="max_length">3</property>
                                 <property name="invisible_char">●</property>
                                 <property name="caps_lock_warning">False</property>
+                                <property name="primary_icon_activatable">False</property>
+                                <property name="secondary_icon_activatable">False</property>
+                                <property name="primary_icon_sensitive">True</property>
+                                <property name="secondary_icon_sensitive">True</property>
                                 <property name="adjustment">adjustment1</property>
                                 <property name="snap_to_ticks">True</property>
                                 <property name="numeric">True</property>
@@ -1526,7 +1498,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                             <child>
                               <object class="GtkButton" id="btnClearThumbnailCache">
                                 <property name="label" translatable="yes">Clear thumbnail cache</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">True</property>
@@ -1606,7 +1577,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                 <child>
                   <object class="GtkButton" id="btnAbout">
                     <property name="label">gtk-about</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
@@ -1637,7 +1607,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                 <child>
                   <object class="GtkButton" id="btnCancel">
                     <property name="label">gtk-cancel</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
@@ -1654,7 +1623,6 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                 <child>
                   <object class="GtkButton" id="btnOk">
                     <property name="label">gtk-ok</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>

--- a/share/cover-thumbnailer-gui.glade
+++ b/share/cover-thumbnailer-gui.glade
@@ -1349,6 +1349,93 @@ along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;.</prop
                     <property name="position">1</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkAlignment" id="alignment12">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="top_padding">10</property>
+                    <child>
+                      <object class="GtkLabel" id="label24">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Thumbnail decorations:</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkHBox" id="hbox12">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkViewport" id="viewport11">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">etched-in</property>
+                        <child>
+                          <object class="GtkImage" id="imgOthersThPreview">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="stock">gtk-missing-image</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkViewport" id="viewport12">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">etched-in</property>
+                        <child>
+                          <object class="GtkVBox" id="vbox19">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkButton" id="btnPickOthersFg">
+                                <property name="label" translatable="yes">Foreground...</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="use_action_appearance">False</property>
+                                <signal name="clicked" handler="on_btnPickOthersFg_clicked" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="position">2</property>


### PR DESCRIPTION
This PR implements the following:

- Allows the installer script to run on MATE
- Implements some code-sharing between the thumbnailer and the configurator GUI
- Fixes failure to generate a thumbnail when thumbnailing using an image file that is smaller than the thumbnail size
- Allows the user to customize the thumbnail background and foreground images via GUI, if they want different decorations. If the user wants no decorations at all, they can pick an all-transparent image.

This PR still does not implement:

- dconf/gsettings integration to get the /org/mate/caja/icon-view/thumbnail-size setting. The thumbnail size is still dictated by the background image size in this version.
-  Internationalization for new strings, sorry :( I felt that crappy google translate translations would be worse than no translation at all.