### PR TITLE
Fix bad regex escape sequence

### DIFF
--- a/cover-thumbnailer.py
+++ b/cover-thumbnailer.py
@@ -654,7 +654,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     #Folders whose name starts with a dot
-    elif CONF['ignored_dotted'] and re.match(".*/\..*", INPUT_FOLDER):
+    elif CONF['ignored_dotted'] and re.match(r".*/\..*", INPUT_FOLDER):
         sys.exit(0)
 
     #Music folders


### PR DESCRIPTION
Caused spam in logs.

I suspect you intended to use `\\.`, but also a raw string works.