### PR TITLE
fix: create thumbnail directory if it doesn't exist

### DIFF
--- a/cover-thumbnailer.py
+++ b/cover-thumbnailer.py
@@ -532,6 +532,10 @@ class Thumb(object):
                freedesktop thumbnail
         """
         if self.thumb is not None:
+            # Ensure the output directory exists
+            output_dir = os.path.dirname(output_path)
+            if output_dir and not os.path.exists(output_dir):
+                os.makedirs(output_dir, exist_ok=True)
             self.thumb.save(output_path, output_format)
         else:
             print("E: [%s:Thumb.save_thumb] No thumbnail created" % __file__)


### PR DESCRIPTION
## Summary
- Ensures output directory exists before saving thumbnails
- Prevents silent failures when ~/.thumbnails/medium doesn't exist
- Uses os.makedirs with exist_ok=True for safety

## Fixes
Closes #23

## Changes
Modified the `save_thumb` method to check if the output directory exists and create it if necessary before attempting to save the thumbnail file.

## Test plan
- Create a test scenario where ~/.thumbnails/medium doesn't exist
- Run cover-thumbnailer on a folder
- Verify the directory is created and thumbnail is saved successfully